### PR TITLE
fix broken markdown syntax in articles

### DIFF
--- a/articles/basics/error_handling.md
+++ b/articles/basics/error_handling.md
@@ -1,7 +1,7 @@
 ---
 title: "Error Handling Functions"
 read_time: "1 min"
-updated: "mar 31, 2015"
+updated: "feb 16, 2016"
 group: "articles"
 permalink: "/tutorials/error-handling.html"
 ---
@@ -9,11 +9,11 @@ These are functions dealing with error handling and logging. They allow you to d
 
 Using these logging functions, you can send messages directly to other machines, to an email, to system logs, etc., so you can selectively log and monitor the most important parts of your applications and websites.
 
-##Installation:
+## Installation:
 
 The error and logging functions are part of the PHP core. There is no installation needed to use these functions.
 
-##Runtime Configuration:
+## Runtime Configuration:
 
 The behaviour of these functions is affected by settings in php.ini. These settings are defined below.
 
@@ -37,7 +37,7 @@ The behaviour of these functions is affected by settings in php.ini. These setti
 | warn_plus_overloading  | NULL    |             | This option is no longer available as of PHP 4.0.0         |
 
 
-##PHP Error and Logging Constants:
+## PHP Error and Logging Constants:
 
 **PHP**: indicates the earliest version of PHP that supports the constant.
 
@@ -60,7 +60,7 @@ You can use any of the constant while configuring your php.ini file.
 | 4096  | E_RECOVERABLE_ERROR | Catchable fatal error. This is like an E_ERROR but can be caught by a user defined handle (see also set_error_handler())  | 5   |
 | 8191  | E_ALL               | All errors and warnings, except of level E_STRICT                                                                         | 5   |
 
-##List of Functions
+## List of Functions
 
 **PHP**: indicates the earliest version of PHP that supports the function.
 

--- a/articles/oop/anti-patterns/architecture-by-implication.md
+++ b/articles/oop/anti-patterns/architecture-by-implication.md
@@ -15,7 +15,7 @@ permalink: "/faq/object-oriented-programming/anti-patterns/architecture-by-impli
 * **Unbalanced Forces**: Management of Complexity, Change, and Risk
 * **Anecdotal Evidence**: "We've done systems like this before!" "There is no risk; we know what we're doing!"
 
-##Background
+## Background
 Dwight Eisenhower said that planning is essential, but plans are inconsequential. Another soldier said that no plans survive first contact with the enemy. The planning culture in modern management owes some credit to Robert McNamara, founder of the RAND Corporation.
 
 In McNamara's approach, plans are generated for speculative purposes, to investigate the potential benefits and consequences of different courses of action. Given the large number of unknowns in systems development, planning for IT systems must be more pragmatic and iterative.
@@ -26,7 +26,7 @@ The unfortunate consequence is that many organizations attempt to formalize too 
 
 A group of CEOs from DoD Systems integration firms was formed to answer the question, "Wherefore art thou architecture?" The goal was to reflect on the changing nature of systems development, which has evolved into the reuse of existing legacy components and commercial software, and away from greenfield, custom code development (see the Reinvent the Wheel AntiPattern).
 
-##General Form
+## General Form
 This AntiPattern is characterized by the lack of architecture specifications for a system under development. Usually, the architects responsible for the project have experience with previous system construction, and therefore assume that documentation is unnecessary.
 
 This overconfidence leads to exacerbated risks in key areas that affect system success. Architecture definitions are often missing from one or more of these areas:
@@ -38,23 +38,23 @@ This overconfidence leads to exacerbated risks in key areas that affect system s
 * Application security architecture that includes thread models and trusted system base.
 * Systems management architecture.
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 * Lack of architecture planning and specification; insufficient definition of architecture for software, hardware, communications, persistence, security, and systems management.
 * Hidden risks caused by scale, domain knowledge, technology, and complexity, all of which emerge as the project progresses.
 * Impending project failure or unsuccessful system due to inadequate performance, excess complexity, misunderstood requirements, usability, and other system characteristics. For example, approximately 1 of 3 systems encounter serious performance problems during development and operations.
 * Ignorance of new technologies.
 * Absence of technical backup and contingency plans.
 
-##Typical Causes
+## Typical Causes
 * No risk management.
 * Overconfidence of managers, architects, and/or developers.
 * Reliance on previous experience, which may differ in critical areas.
 * Implicit and unresolved architecture issues caused by gaps in systems engineering.
 
-##Known Exceptions
+## Known Exceptions
 The Architecture by Implication AntiPattern is acceptable for a repeated solution, where there are minor differences in the code, such as installation scripts. This AntiPattern may also be useful in a new project domain as an exploratory effort to determine whether existing techniques are transferable into a new area.
 
-##Refactored Solution
+## Refactored Solution
 The refactored solution to the Architecture by Implication AntiPattern entails an organized approach to systems architecture definition, and relies on multiple views of the system. Each view models the system from the perspective of a system stakeholder, who may be real or imaginary, individual or aggregate. Each stakeholder is responsible for a high-priority set of questions and issues, and each view represents the entire information system and answers these key questions and issues.
 
 The views comprising a set of diagrams, tables, or specifications, are linked for consistency. Generally, a view is a lightweight specification. The purpose of the architecture documentation is to communicate architecture decisions and other issues resolutions. The documentation should be easy to understand and inexpensive to maintain.
@@ -76,7 +76,7 @@ The steps to define a system architecture using viewpoints are as follows :
 9. *Validate the implementation*. The blueprints should represent an "as-built" design. Determine any deltas between the blueprints and the system implementation. Decide whether these differences should result in system modifications of updates to the blueprints. Upgrade the documentation for consistency.
 We refer to this method as the goal-question architecture (GQA), analogous to the goal-question metric approach in software metrics
 
-##Variations
+## Variations
 A number of approaches consider the system architecture using viewpoints; in some, the viewpoints are predefined. Most of these approaches are open-ended, in that one can select additional viewpoints as described.
 
 The Reference Model for Open Distributed Process (RM-ODP) is a popular, useful standard for distributed architectures. RM-ODP defines five standard viewpoints: enterprise, information, computational, engineering, and technology It also defines a useful set of transparency properties for distributed infrastructure through the engineering viewpoint.
@@ -87,7 +87,7 @@ A third approach, the Command, Communication, Control, Computer, Intelligence, S
 
 A fourth, the 4 + 1 Model View, is a viewpoint-based architecture approach supported by software engineering tools, such as Rational Rose The viewpoints include logical, use-case, process, implementation, and deployment. Finally, GQA is a generalization of the underlying method used in several of these architecture approaches
 
-##Example
+## Example
 A common but bad practice is object-oriented modeling without defining the viewpoint. In most modeling approaches, there is a blurring of the viewpoints. Many of the modeling constructs contain implementation detail, and the default practice is to intermingle implementation and specification constructs.
 
 Three fundamental viewpoints are: conceptual, specification, and implementation The conceptual viewpoint defines the system from the perspective of the user. This is typically referred to as an analysis model. The distinction between what is automated and what is not is usually not represented in the model; rather, the model is drawn so that a user can explain and defend it to his or her peers.
@@ -102,10 +102,10 @@ However, the manager was a good software engineer with no distributed object tec
 
 In addition, the architecture and subsequent design were based on the OMA view of the DOT world, rather than DCOM. This led to an attempt to deliver CORBA services under a DCOM architecture. The resulting product suffered from a set of components that had no DOT consistency and were poor performers. Also, SIs found it very difficult to use, due to lack of a standardized approach. Finally, it failed in the marketplace.
 
-##Related Solutions
+## Related Solutions
 Architecture by Implication AntiPattern differs from the Stovepipe Systems AntiPattern in scope; the latter focuses on deficiencies in computational architecture. In particular, it identifies how improper abstraction of subsystem APIs leads to brittle architecture solutions. In contrast, the Architecture by Implication AntiPattern involves planning gaps constituted of multiple architecture viewpoints.
 
-##Applicability To Other Viewpoints And Scales
+## Applicability To Other Viewpoints And Scales
 This AntiPattern significantly increases risk for managers, who defer important decisions until failures occur; often, it is too late to recover. Developers suffer from a lack of guidance for system implementation.
 
 They are given de facto responsibility for key architectural decisions for which they may not have the necessary architectural perspective. Systemwide consequences of interface design decisions should be considered; in particular: system adaptability, consistent interface abstractions, metadata availability, and management of complexity.

--- a/articles/oop/anti-patterns/autogenerated-stovepipe.md
+++ b/articles/oop/anti-patterns/autogenerated-stovepipe.md
@@ -12,7 +12,7 @@ For example, the existing interfaces may be using fine-grain operations to trans
 
 Local operations often make various assumptions about location, including address space and access to the local file system. Excess complexity can arise when multiple existing interfaces are exposed across a larger-scale distributed system.
 
-##Refactored Solution
+## Refactored Solution
 
 When designing distributed interfaces for existing software, the interfaces should be reengineered. A separate, larger-grained object model should be considered for the distributed interfaces.
 

--- a/articles/oop/anti-patterns/continuous-obsolescence.md
+++ b/articles/oop/anti-patterns/continuous-obsolescence.md
@@ -28,7 +28,7 @@ From the technology marketers' perspective, there are two key factors: mindshare
 
 For those following the technology, rapid innovation contributes to mindshare; in other words, there is always new news about technology X. Once a dominant marketshare is obtained, the suppliers' primary income is through obsolescence and replacement of earlier product releases. The more quickly technologies obsolesce (or are perceived as obsolete), the higher the income.
 
-##Refactored Solution
+## Refactored Solution
 
 An important stabilizing factor in the technology market is open systems standards. A consortium standard is the product of an industry concensus that requires time and investment.
 
@@ -36,7 +36,7 @@ Joint marketing initiatives build user awareness and acceptance as the technolog
 
 The advantages of a rapidly obsolescing technology are transitive. Architects and developers should depend upon interfaces that are stable or that they control. Open systems standards give a measure of stability to an otherwise chaotic technology market.
 
-##Variations
+## Variations
 
 The Wolf Ticket Mini-AntiPattern describes various approaches that consumers can use to influence product direction toward improved product quality.
 

--- a/articles/oop/anti-patterns/cover-your-assets.md
+++ b/articles/oop/anti-patterns/cover-your-assets.md
@@ -6,7 +6,7 @@ group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/cover-your-assets/"
 ---
 
-#Cover Your Assets
+# Cover Your Assets
 
 Document-driven software processes often produce less-than-useful requirements and specifications because the authors evade making important decisions. In order to avoid making a mistake, the authors take a safer course and elaborate upon alternatives.
 
@@ -14,7 +14,7 @@ The resulting documents are voluminous and become an enigma; there is no useful 
 ![Cover Your Assets antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/paper.jpg "Cover Your Assets antipattern")
 When no decisions are made and no priorities are established, the documents have limited value. It is unreasonable to have hundreds of pages of requirements that are all equally important or mandatory. The developers are left without much useful guidance about what to implement in what priority.
 
-##Refactored Solution
+## Refactored Solution
 Architecture blueprints are abstractions of information systems that facilitate communication of requirements and technical plans between the users and developers An architecture blueprint is a small set of diagrams and tables that communicate the operational, technical, and systems architecture of current and future information systems A typical blueprint comprises no more than a dozen diagrams and tables, and can be presented in an hour or less as a viewgraph presentation.
 
 Architecture blueprints are particularly useful in an enterprise with multiple information systems. Each system can establish its architecture blueprints, then the organization can compile enterprisewide blueprints based upon the system-specific details. Blueprints should characterize both existing systems and planned extensions.

--- a/articles/oop/anti-patterns/cut-and-paste-programming.md
+++ b/articles/oop/anti-patterns/cut-and-paste-programming.md
@@ -15,11 +15,11 @@ permalink: "/faq/object-oriented-programming/anti-patterns/what-is-cut-and-paste
 **Unbalanced Forces**: Management of Resources, Technology Transfer
 **Anecdotal Evidence**: "Hey, I thought you fixed that bug already, so why is it doing this again?" "Man, you guys work fast. Over 400,000 lines of code in three weeks is outstanding progress!"
 
-##Background
+## Background
 
 Cut-and-Paste Programming is a very common, but degenerate form of software reuse which creates maintenance nightmares. It comes from the notion that it's easier to modify existing software than program from scratch. This is usually true and represents good software instincts. However, the technique can be easily over used.
 
-##General Form
+## General Form
 
 This AntiPattern is identified by the presence of several similar segments of code interspersed throughout the software project. Usually, the project contains many programmers who are learning how to develop software by following the examples of more experienced developers.
 
@@ -27,7 +27,7 @@ However, they are learning by modifying code that has been proven to work in sim
 
 Furthermore, it's easy to extend the code as the developer has full control over the code used in his or her application and can quickly meet short-term modifications to satisfy new requirements.
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * The same software bug reoccurs throughout software despite many local fixes.
 * Lines of code increase without adding to overall productivity.
@@ -41,7 +41,7 @@ Furthermore, it's easy to extend the code as the developer has full control over
 * Developers create multiple unique fixes for bugs with no method of resolving the variations into a standard fix.
 * Cut-and-Paste Programming form of reuse deceptively inflates the number of lines of code developed without the expected reduction in maintenance costs associated with other forms of reuse.
 
-##Typical Causes
+## Typical Causes
 
 * It takes a great deal of effort to create reusable code, and organization emphasizes short-term payoff more than long-term investment.
 * The context or intent behind a software module is not preserved along with the code.
@@ -53,10 +53,11 @@ Furthermore, it's easy to extend the code as the developer has full control over
 * There is a lack of forethought or forward thinking among the development teams.
 * Cut-and-Paste AntiPattern is likely to occur when people are unfamiliar with new technology or tools; as a result, they take a working example and modify it, adapting it to their specific needs.
 
-#Known Exceptions
+# Known Exceptions
 
 The Cut-and-Paste Programming AntiPattern is acceptable when the sole aim is to get the code out of the door as quickly as possible. However, the price paid is one of increased maintenance.
-##Refactored Solution
+
+## Refactored Solution
 
 Cloning frequently occurs in environments where white-box reuse is the predominant form of system extension. In white-box reuse, developers extend systems primarily though inheritance. Certainly, inheritance is an essential part of object-oriented development, but it has several drawbacks in large systems.
 
@@ -80,7 +81,7 @@ Effective refactoring to eliminate multiple versions involves three stages: code
 
 Configuration management is a set of policies drawn up to aid in the prevention of future occurrences of Cut-and-Paste Programming. For the most part, this requires monitoring and detection policies (code inspections, reviews, validation), in addition to educational efforts. Management buy-in is essential to ensure funding and support throughout all three stages.
 
-##Example
+## Example
 
 There is one piece of code that we suspect has been cloned repeatedly throughout several organizations and probably is still cloned today. This piece of code has been observed several hundred times across dozens of organizations. It is a code file that implements a linked-list class without the use of templates or macros.
 
@@ -88,7 +89,7 @@ Instead, the data structure stored by the linked list is defined in a header fil
 
 On occasion, this code has been modified to fix this defect; however, more often than not, it still exists. It's clearly the same code set; the variable names, the instructions, and even the formatting is exactly the same in each and every case. Even the file is typically named <prefix>link.c, where the prefix is one or two letters that cryptically refer to the data structure managed by the list.
 
-##Related Solutions
+## Related Solutions
 
 Spaghetti Code often contains several instances of the Cut-and-Paste Programming AntiPattern. Because Spaghetti Code is not structured for easy component reuse, in many cases, Cut-and-Paste Programming is the only means available for reusing existing segments of code.
 

--- a/articles/oop/anti-patterns/dead-end.md
+++ b/articles/oop/anti-patterns/dead-end.md
@@ -6,7 +6,7 @@ group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/what-is-dead-end/"
 ---
 
-#Dead End
+# Dead End
 **Also Known As**: Kevorkian Component
 
 
@@ -18,7 +18,7 @@ The decision to modify a reusable component by a system's integrator is often se
 
 The longer-term support burden becomes untenable when trying to deal with the future application versions and the "reusable component" vendor's releases. The only time we saw this work was when the system's integrator arranged with the reusable component vendor that the SI modifications would be included in the next release of the vendor product. It was pure luck that their objectives were the same.
 
-#Refactored Solution
+# Refactored Solution
 
 Avoid COTS Customization and modifications to reusable software. Minimize the risk of a Dead End by using mainstream platforms and COTS infrastructure, and upgrading according to the supplier's release schedule.
 

--- a/articles/oop/anti-patterns/functional-decomposition.md
+++ b/articles/oop/anti-patterns/functional-decomposition.md
@@ -6,7 +6,7 @@ group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/what-is-functional-decomposition/"
 ---
 
-##Functional Decomposition
+## Functional Decomposition
 
 * **AntiPattern Name**: Functional Decomposition
 * **Also Known As**: No Object-Oriented AntiPattern "No OO"
@@ -18,13 +18,13 @@ permalink: "/faq/object-oriented-programming/anti-patterns/what-is-functional-de
 * **Anecdotal Evidence**:
 "This is our ‘main' routine, here in the class called LISTENER."
 
-##Background
+## Background
 
 Functional Decomposition is good in a procedural programming environment. It's even useful for understanding the modular nature of a larger-scale application.
 
 Unfortunately, it doesn't translate directly into a class hierarchy, and this is where the problem begins. In defining this AntiPattern, the authors started with Michael Akroyd's original thoughts on this topic. We have reformatted it to fit in with our template, and extended it somewhat with explanations and diagrams.
 
-##General Form
+## General Form
 
 This AntiPattern is the result of experienced, nonobject-oriented developers who design and implement an application in an object-oriented language. When developers are comfortable with a "main" routine that calls numerous subroutines, they may tend to make every subroutine a class, ignoring class hierarchy altogether (and pretty much ignoring object orientation entirely).
 
@@ -34,7 +34,7 @@ The resulting code resembles a structural language such as Pascal or FORTRAN in 
 
 You will most likely encounter this AntiPattern in a C shop that has recently gone to C++, or has tried to incorporate CORBA interfaces, or has just implemented some kind of object tool that is supposed to help them. It's usually cheaper in the long run to spend the money on object-oriented training or just hire new programmers who think in objects.
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * Classes with "function" names such as Calculate_Interest or Display_Table may indicate the existence of this AntiPattern.
 * All class attributes are private and used only inside the class.
@@ -45,17 +45,17 @@ You will most likely encounter this AntiPattern in a C shop that has recently go
 * No hope of ever obtaining software reuse.
 * Frustration and hopelessness on the part of testers.
 
-##Typical Causes
+## Typical Causes
 
 * Lack of object-oriented understanding. The implementers didn't "get it." This is fairly common when developers switch from programming in a nonobject-oriented programming language to an object-oriented programming language. Because there are architecture, design, and implementation paradigm changes, object-orientation can take up to three years for a company to fully achieve.
 * Lack of architecture enforcement. When the implementers are clueless about object orientation, it doesn't matter how well the architecture has been designed; they simply won't understand what they're doing. And without the right supervision, they will usually find a way to fudge something using the techniques they do know.
 * Specified disaster. Sometimes, those who generate specifications and requirements don't necessarily have real experience with object-oriented systems. If the system they specify makes architectural commitments prior to requirements analysis, it can and often does lead to AntiPatterns such as Functional Decomposition.
 
-##Known Exceptions
+## Known Exceptions
 
 The Functional Decomposition AntiPattern is fine when an object-oriented solution is not required. This exception can be extended to deal with solutions that are purely functional in nature but wrapped to provide an object-oriented interface to the implementation code.
 
-##Refactored Solution
+## Refactored Solution
 
 If it is still possible to ascertain what the basic requirements are for the software, define an analysis model for the software, to explain the critical features of the software from the user's point of view. This is essential for discovering the underlying motivation for many of the software constructs in a particular code base, which have been lost over time. For all of the steps in the Functional Decomposition AntiPattern solution, provide detailed documentation of the processes used as the basis for future maintenance efforts.
 
@@ -70,7 +70,7 @@ For classes that fall outside of the design model, use the following guidelines:
 
 Examine the design and find similar subsystems. These are reuse candidates. As part of program maintenance, engage in refactoring of the code base to reuse code between similar subsystems (see the Spaghetti Code solution for a detailed description of software refactoring).
 
-##Example
+## Example
 
 Functional Decomposition is based upon discrete functions for the purpose of data manipulation, for example, the use of Jackson Structured Programming. Functions are often methods within an object-oriented environment. The partitioning of functions is based upon a different paradigm, which leads to a different grouping of functions and associated data.
 
@@ -89,7 +89,7 @@ Next figure then shows the object-oriented view of a customer loan application. 
 
 ![Functional decomposition antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/FunctionalDecomposition-2-2x.png "Functional decomposition antipattern")
 
-##Related Solutions
+## Related Solutions
 
 If too much work has already been invested in a system plagued by Functional Decomposition, you may be able to salvage things by taking an approach similar to the alternative approach addressed in the Blob AntiPattern.
 
@@ -97,7 +97,7 @@ Instead of a bottom-up refactoring of the whole class hierarchy, you may be able
 
 Function classes can then be "massaged" into quasi-object-oriented classes by combining them and beefing them up to carry out some of their own processing at the direction of the modified "coordinator" class. This process may result in a class hierarchy that is more workable
 
-##Applicability To Other Viewpoints And Scales
+## Applicability To Other Viewpoints And Scales
 
 Both architectural and managerial viewpoints play key roles in either initial prevention or ongoing policing against the Functional Decomposition AntiPattern. If a correct object-oriented architecture was initially planned and the problem occurred in the development stages, then it is a management challenge to enforce the initial architecture.
 

--- a/articles/oop/anti-patterns/golden-hammer.md
+++ b/articles/oop/anti-patterns/golden-hammer.md
@@ -6,7 +6,7 @@ group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/what-is-golden-hammer/"
 ---
 
-##Golden Hammer
+## Golden Hammer
 **AntiPattern Name**: Golden Hammer
 **Also Known As**: Old Yeller, Head-in-the sand
 **Most Applicable Scale**: Application
@@ -21,11 +21,11 @@ permalink: "/faq/object-oriented-programming/anti-patterns/what-is-golden-hammer
 
 "Maybe we shouldn't have used Excel macros for this job after all."
 
-##Background
+## Background
 
 This is one of the most common AntiPatterns in the industry. Frequently, a vendor, specifically a database vendor, will advocate using its growing product suite as a solution to most of the needs of an organization. Given the initial expense of adopting a specific database solution, such a vendor often provides extensions to the technology that are proven to work well with its deployed products at greatly reduced prices.
 
-##General Form
+## General Form
 
 A software development team has gained a high level of competence in a particular solution or vendor product, referred to here as the Golden Hammer. As a result, every new product or development effort is viewed as something that is best solved with it. In many cases, the Golden Hammer is a mismatch for the problem, but minimal effort is devoted to exploring alternative solutions.
 
@@ -35,7 +35,7 @@ This AntiPattern results in the misapplication of a favored tool or concept. Dev
 
 Frequently, an advocate will propose the Golden Hammer and its associated product suite as a solution to most of the needs of an organization. Given the initial expense of adopting a specific solution, Golden Hammer advocates will argue that future extensions to the technology, which are designed to work with their existing products, will minimize risk and cost.
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * Identical tools and products are used for wide array of conceptually diverse products.
 * Solutions have inferior performance, scalability, and so on when compared to other solutions in the industry.
@@ -46,7 +46,7 @@ Frequently, an advocate will propose the Golden Hammer and its associated produc
 * Existing products dictate design and system architecture.
 * New development relies heavily on a specific vendor product or technology.
 
-##Typical Causes
+## Typical Causes
 
 * Several successes have used a particular approach.
 * Large investment has been made in training and/or gaining experience in a product or technology.
@@ -54,7 +54,7 @@ Frequently, an advocate will propose the Golden Hammer and its associated produc
 * Reliance on proprietary product features that aren't readily available in other industry products.
 * "Corncob" proposing the solution (see Corncob AntiPattern).
 
-##Known Exceptions
+## Known Exceptions
 
 The Golden Hammer AntiPattern sometimes works:
 
@@ -85,13 +85,13 @@ Another management-level way of eliminating or avoiding the Golden Hammer AntiPa
 
 Finally, management must actively invest in the professional development of software developers, as well as reward developers who take initiative in improving their own work.
 
-##Variations
+## Variations
 
 A common variation of Golden Hammer occurs when a developer uses a favorite software concept obsessively. For example, some developers learn one or two of the GoF patterns and apply them to all phases of software analysis, design, and implementation.
 
 Discussions about intent or purpose are insufficient to sway them from recognizing the applicability of the design pattern's structure and force-fitting its use throughout the entire development process. Education and mentoring is required to help people become aware of other available approaches to software system construction.
 
-##Example
+## Example
 
 A common example of the Golden Hammer AntiPattern is a database-centric environment with no additional architecture except that which is provided by the database vendor. In such an environment, the use of a particular database is assumed even before object-oriented analysis has begun. As such, the software life cycle frequently begins with the creation of an entity-relationship (E-R) diagram that is produced as a requirements document with the customer.
 
@@ -105,7 +105,7 @@ At some point, it may be necessary to interoperate with systems that either do n
 
 Another example is an insurance company with several stovepipe legacy systems that decided in its move to client/server that Microsoft Access should be the key part of the solution for persistence. The entire front end of the call-center system was architected around an early version of this product. Thereafter, the system's future was fully constrained by the development path of the database product because of a bad architecture decision. Needless to say, the system lasted less than six months.
 
-##Related Solutions
+## Related Solutions
 
   * Lava Flow. This AntiPattern results when the Golden Hammer AntiPattern is applied over the course of several years and many projects. Typically, older sections based on earlier versions of the Golden Hammer are delegated to remote, seldom-used parts of the overall application. Developers become reluctant to modify these sections, which build up over time and add to the overall size of the application while implementing functions that are seldom, if ever, used by the customer.
  * Vendor Lock-In. Vendor lock-in is when developers actively receive vendor support and encouragement in applying the Golden Hammer AntiPattern. A software project is actively committed to relying upon a single vendor's approach in designing and implementing an object-oriented system.

--- a/articles/oop/anti-patterns/software-development-antipatterns.md
+++ b/articles/oop/anti-patterns/software-development-antipatterns.md
@@ -6,7 +6,7 @@ group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/software-development-antipatterns/"
 ---
 
-#Software Development AntiPatterns
+# Software Development AntiPatterns
 
 Good software structure is essential for system extension and maintenance. Software development is a chaotic activity, therefore the implemented structure of systems tends to stray from the planned structure as determined by architecture, analysis, and design.
 

--- a/articles/oop/anti-patterns/spaghetti-code.md
+++ b/articles/oop/anti-patterns/spaghetti-code.md
@@ -23,13 +23,13 @@ permalink: "/faq/object-oriented-programming/anti-patterns/what-is-spaghetti-cod
 
 "The quality of your software structure is an investment for future modification and extension."
 
-##Background
+## Background
 
 The Spaghetti Code AntiPattern is the classic and most famous AntiPattern; it has existed in one form or another since the invention of programming languages. Nonobject-oriented languages appear to be more susceptible to this AntiPattern, but it is fairly common among developers who have yet to fully master the advanced concepts underlying object orientation.
 
 ![Spaghetti code antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/spagetti.jpg "Spaghetti code antipattern")
 
-##General Form
+## General Form
 
 Spaghetti Code appears as a program or system that contains very little software structure. Coding and progressive extensions compromise the software structure to such an extent that the structure lacks clarity, even to the original developer, if he or she is away from the software for any length of time.
 
@@ -37,7 +37,7 @@ If developed using an object-oriented language, the software may include a small
 
 Furthermore, the object methods are invoked in a very predictable manner, and there is a negligible degree of dynamic interaction between the objects in the system. The system is very difficult to maintain and extend, and there is no opportunity to reuse the objects and modules in other similar systems.
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * After code mining, only parts of object and methods seem suitable for reuse. Mining Spaghetti Code can often be a poor return on investment; this should be taken into account before a decision to mine is made.
 * Methods are very process-oriented; frequently, in fact, objects are named as processes.
@@ -51,20 +51,20 @@ Furthermore, the object methods are invoked in a very predictable manner, and th
 * Follow-on maintenance efforts contribute to the problem.
 * Software quickly reaches a point of diminishing returns; the effort involved in maintaining an existing code base is greater than the cost of developing a new solution from the ground up.
 
-##Typical Causes
+## Typical Causes
 
 * Inexperience with object-oriented design technologies.
 * No mentoring in place; ineffective code reviews.
 * No design prior to implementation.
 * Frequently the result of developers working in isolation.
 
-##Known Exceptions
+## Known Exceptions
 
 The Spaghetti Code AntiPattern is reasonably acceptable when the interfaces are coherent and only the implementation is spaghetti. This is somewhat like wrapping a nonobject-oriented piece of code. If the lifetime of the component is short and cleanly isolated from the rest of the system, then some amount of poor code may be tolerable.
 
 The reality of the software industry is that software concerns usually are subservient to business concerns, and, on occasion, business success is contingent on delivering a software product as rapidly as possible. If the domain is not familiar to the software architects and developers, it may be better to develop products to gain an understanding of the domain with the intention of designing products with an improved architecture at some later date
 
-##Refactored Solution
+## Refactored Solution
 
 Software refactoring (or code cleanup) is an essential part of software development Seventy percent or more of software cost is due to extensions, so it is critical to maintain a coherent software structure that supports extension.
 
@@ -78,7 +78,7 @@ Code cleanup also supports performance enhancement. Typically, performance optim
 
 The first goal is to achieve a satisfactory structure; the second is to determine by measurement where the performance-critical code exists; the third is to carefully introduce necessary structure compromises to enhance performance. It is sometimes necessary to reverse the performance enhancement changes in software to provide for essential system extensions. Such areas merit additional documentation, in order to preserve the software structure in future releases.
 
-##Kill Spaghetti Code AntiPattern through prevention
+## Kill Spaghetti Code AntiPattern through prevention
 
 The best way to resolve the Spaghetti Code AntiPattern is through prevention; that is, to think, then develop a plan of action before writing. If, however, the code base has already degenerated to the point that it is unmaintainable, and if reengineering the software is not an option, there are still steps that can be taken to avoid compounding the problem.
 
@@ -93,7 +93,7 @@ In short, commit to actively refactoring and improving Spaghetti Code to as grea
 
 Empirical evidence suggests that the benefits of refactoring the software greatly outweigh the risk that the extra modifications may generate new defects.
 
-##Other prevention methods
+## Other prevention methods
 
 If prevention of Spaghetti Code is an option, or if you have the luxury of fully engineering a Spaghetti Code application, the following preventative measures may be taken:
 
@@ -111,7 +111,7 @@ Once development begins, proceed to incrementally examine other parts of the dom
 
 Again, Spaghetti Code is far less likely to occur if there is an overall software process in which the requirements and design are specified in advance of the implementation, instead of occurring concurrently.
 
-##Example
+## Example
 
 This is a frequent problem demonstrated by people new to object-oriented development, who map system requirements directly to functions, using objects as a place to group related functions. Each function contains an entire process flow that completely implements a particular task.
 
@@ -119,7 +119,7 @@ For example, the code segment that follows contains functions such as initMenus(
 
 The object retains little or no state information between successive invocations; rather, the class variables are temporary storage locations to handle intermediate results of a single process flow.
 
-##Related Solutions
+## Related Solutions
 
 * Analysis Paralysis. This AntiPattern is the result of taking the solution to its logical extreme. Rather than developing code ad hoc without a design to guide the overall structure of the code, Analysis Paralysis produces a detailed design without ever reaching a point at which implementation can commence.
 * Lava Flow. This AntiPattern frequently contains several examples of Spaghetti Code that discourage the refactoring of the existing code base. With Lava Flow, the code base had a logical purpose at some point in its life cycle, but portions became obsolescent, yet remained as part of the code base.

--- a/articles/oop/anti-patterns/stovepipe-enterprise.md
+++ b/articles/oop/anti-patterns/stovepipe-enterprise.md
@@ -15,13 +15,13 @@ permalink: "/faq/object-oriented-programming/anti-patterns/what-is-stovepipe-ent
 * **Unbalanced Forces**: Management of Change, Resources, Technology Transfer
 * **Anecdotal Evidence**: "Can I have my own island (of automation)?"
 
-##Background
+## Background
 
 Stovepipe is a popular term used to describe software systems with ad hoc architectures. It is a metaphor to the exhaust pipes of wood-burning stoves, so-called pot-bellied stoves.
 
 Since wood burning produces corrosive substances that erode metal, a stovepipe must be constantly maintained and repaired in order to avoid leakage. Often, the pipes are repaired with any materials at hand, thus wood-burning stovepipes quickly become a hodgepodge of ad hoc repairs—hence, the reference is used to describe the ad hoc structure of many software systems.
 
-##General Form
+## General Form
 
 Multiple systems within an enterprise are designed independently at every level. Lack of commonality inhibits interoperability between systems, prevents reuse, and drives up cost; in addition, reinvented system architecture and services lack quality structure supporting adaptability.
 
@@ -31,7 +31,7 @@ The top two layers include the value-added functional services and the mission-s
 
 ![Stovepipe Enterprise antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/Stovepipe-Enterprise2-1-2x.png "Stovepipe Enterprise antipattern")
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * Incompatible terminology, approaches, and technology between enterprise systems.
 * Brittle, monolithic system architectures and undocumented architectures.
@@ -43,7 +43,7 @@ The top two layers include the value-added functional services and the mission-s
 * Excessive maintenance costs due to changing business requirements; the need to extend the system to incorporate new products and technologies.
 * Employee turnover, which causes project discontinuity and maintenance problems.
 
-##Typical Causes
+## Typical Causes
 
 * Lack of an enterprise technology strategy, specifically:
     * Lack of a standard reference model
@@ -53,13 +53,13 @@ The top two layers include the value-added functional services and the mission-s
 * Lack of knowledge of the technology standard being used.
 * Absence of horizontal interfaces in system integration solutions.
 
-##Known Exceptions
+## Known Exceptions
 
 The Stovepipe Enterprise AntiPattern is unacceptable for new systems at an enterprise level in this day and age, particularly when most companies are facing the need to extend their business systems. However, when companies grow by takeover or merger, the Stovepipe AntiPattern is likely to occur; in which case, wrapping some systems can be an intermediate solution.
 
 Another exception is when a common service layer is implemented across the enterprise systems. This is usually a manifestation of the Vendor Lock-In AntiPattern. These systems have a common horizontal component; for example, in banking, this is often true of databases such as DB2 and Oracle.
 
-##Refactored Solution
+## Refactored Solution
 
 Coordination of technologies at several levels is essential to avoid a Stovepipe Enterprise. Initially, the selection of standards can be coordinated through the definition of a standards reference model.
 
@@ -87,13 +87,13 @@ The specification models include:
 
 The following sections describe these models, each of which is part of an overall enterprise-architecture plan. The plan provides effective coordination between projects and reduces the need for point-to-point interoperability solutions.
 
-##Open Systems Reference Model
+## Open Systems Reference Model
 
 An open systems reference model contains a high-level architecture diagram and a list of target standards for system development projects. The purpose of this model is to identify all of the candidate standards for projects, to coordinate open-systems strategies.
 
 An off-the-shelf reference model of this type is the IEEE POSIX 1003.0 standard. This section of POSIX lists a wide range of open systems standards with respect to applicability, maturity, commercial support, and other factors. This POSIX standard is the starting point for many enterprise-specific reference models.
 
-##Technology Profile
+## Technology Profile
 
 When open-systems reference models were invented less than 10 years ago, they were thought to be the complete answer to systems interoperability. Unfortunately, developers were uncertain how these models affected their projects. A key problem is that reference models define future architecture goals with an unspecified time frame for implementation. Also, approximately a third of the items change status every year, due to the activities of standards bodies.
 
@@ -101,7 +101,7 @@ Technology profiles were invented to define the short-term standards plan for sy
 
 The technology profile clarifies what the developer has to do about the reference model standards; for example, the US-DOD Joint Technical Architecture is a technical profile that identifies standards for current implementation.
 
-##Operating Environment
+## Operating Environment
 
 Most large enterprises have heterogeneous hardware and software architectures, but even with a consistent infrastructure, varying installation practices can cause serious problems for enterprise interoperability, software reuse, security, and systems management.
 
@@ -109,19 +109,19 @@ An operating environment defines product releases and installation conventions t
 
 The enterprise can encourage compliance with these conventions through technical support services and purchasing procedures; in other words, the enterprise can influence the adoption of the recommended environments by making them the easiest system configurations to obtain and support. Variations from the operating environment must be supported locally at extra cost.
 
-##System Requirements Profile
+## System Requirements Profile
 
 Enterprise architecture planning often produces broad, high-level requirements documents. For any particular family of systems, the requirements may be unclear to developers because of the sheer volume of information. A system requirements profile is a summary of key requirements for a family of related systems. The time frame is short term. Ideally, this document is only a few dozen pages in length, written to clarify the intended implementation goals for component systems and application development projects.
 
 The system requirements profile identifies necessary scoping of system capabilities, and thus is the stepping-off point for enterprise requirements planning. The balance of the enterprise planning models are architecture and design specifications (described in subsequent sections), which are expressed through object-oriented models and comprise a set of object-oriented software architectures.
 
-##Enterprise Architecture
+## Enterprise Architecture
 
 An enterprise architecture is a set of diagrams and tables that define a system or family of systems from various stakeholder viewpoints; thus, the enterprise architecture comprises views of the entire system. Current and future time frames are depicted, and each view addresses the issues posed by principal stakeholders, such as end users, developers, systems operators, and technical specialists.
 
 Consistency of the architecture views and notations across projects is important, for enterprise architectures enable technical communication across projects. Reuse and interoperability opportunities can be identified when projects share their architectures. Since individual projects have the most knowledge of the technical details, project-specific architectures can be compiled into accurate, enterprisewide architectures.
 
-##Computational Facilities Architecture
+## Computational Facilities Architecture
 
 As just explained, enterprise architectures are important communication tools for end users and architects. Each of the remaining specifications detail the computational architecture that defines interfaces for interoperability and reuse.
 
@@ -131,13 +131,13 @@ A CFA partitions the enterprise's interoperability needs into manageable specifi
 
 Achieving consensus on the facilities in a CFA is a key challenge for many enterprises. Misunderstandings abound regarding the role of the facilities in relation to external requirements, the need for system independence, the definition of common abstractions, and the necessity of limiting the scope of the facilities.
 
-##Interoperability Specification
+## Interoperability Specification
 
 An interoperability specification defines the technical details of a computational facility. Typical interoperability specifications include APIs defined in IDL and common data object definitions.
 
 Interoperability specifications establish key points of interoperability in a manner that is independent of any particular system of subsystem implementation. Architecture mining is a particularly effective process for creating these specifications During system maintenance, the key points of interoperability become value-added entry points for system extension.
 
-##Development Profile
+## Development Profile
 
 An interoperability specification alone is not enough to assure successful integration, because the semantics of APIs can be interpreted differently by different implementors. Robust API designs have built-in flexibility that enable extension and reuse, and details of their usage are often discovered in the development process. Some of these details may be unique to a particular set of systems.
 
@@ -145,7 +145,7 @@ A development profile records the implementation plans and developer agreements 
 
 While it is important to configuration-control all of these models, development profiles are working documents that evolve throughout development and maintenance life cycles. Multiple development profiles may exist for a single API specification, each of which addresses the integration needs of a particular domain or family of systems.
 
-##Example
+## Example
 
 System 1 and System 2 represent two Stovepipe Systems in the same enterprise. While similar in many ways, these systems lack commonality; they use different database products, different office automation tools, have different software interfaces, and use unique graphical user interfaces (GUIs). The potential commonalities between these systems was not recognized and therefore not utilized by the designers and developers.
 
@@ -157,7 +157,7 @@ This is the supported direction for future migration of the enterprise. The ente
 
 ![Stovepipe Enterprise antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/Stovepipe-Enterprise-5-2x.png "Stovepipe Enterprise antipattern")
 
-##Related Solutions
+## Related Solutions
 
 Reinvent the Wheel is an AntiPattern that comprises a subset of the overall problem of Stovepipe Systems. Reinvent the Wheel is focused upon the lack of maturity of designs and implementations caused by the lack of communication between development projects.
 
@@ -165,7 +165,7 @@ Standards reference model, operating environment, and profile are solutions from
 
 Examples of standards reference models include the IEEE POSIX.0, NIST Application
 
-##Applicability To Other Viewpoints And Scales
+## Applicability To Other Viewpoints And Scales
 
 Stovepipe Enterprises are often the consequence of organizational boundaries imposed by management. Organizational structures that inhibit communication and the transfer of technology produce the kind of disconnects that result in the lack of coordination that characterizes Stovepipe Enterprises.
 

--- a/articles/oop/anti-patterns/stovepipe-system.md
+++ b/articles/oop/anti-patterns/stovepipe-system.md
@@ -15,13 +15,13 @@ permalink: "/faq/object-oriented-programming/anti-patterns/what-is-stovepipe-sys
 * **Unbalanced Forces**: Management of Complexity, Change
 * **Anecdotal Evidence**: "The software project is way over-budget; it has slipped its schedule repeatedly; my users still don't get the expected features; and I can't modify the system. Every component is a stovepipe."
 
-##Background
+## Background
 
 Stovepipe System is a widely used derogatory name for legacy software with undesirable qualities. In this AntiPattern, we attribute the cause of these negative qualities to the internal structure of the system.
 
 An improved system structure enables the evolution of the legacy system to meet new business needs and incorporate new technologies seamlessly. By applying the recommended solution, the system can gain new capabilities for adaptability that are uncharacteristic of Stovepipe Systems.
 
-##General Form
+## General Form
 
 The Stovepipe System AntiPattern is the single-system analogy of Stovepipe Enterprise, which involves a lack of coordination and planning across a set of systems. The Stovepipe System AntiPattern addresses how the subsystems are coordinated within a single system.
 
@@ -35,7 +35,7 @@ As each new capability and alteration is integrated, system complexity increases
 
 ![Stovepipe system antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/Stovepipe-System-1-2x.png "Stovepipe system antipattern")
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * Large semantic gap between architecture documentation and implemented software; documentation does not correspond to system implementation.
 * Architects are unfamiliar with key aspects of integration solution.
@@ -48,7 +48,7 @@ As each new capability and alteration is integrated, system complexity increases
 * Changes to the systems become increasingly difficult.
 System modifications become increasingly likely to introduce new serious bugs.
 
-##Typical Causes
+## Typical Causes
 
 * Multiple infrastructure mechanisms used to integrate subsystems; absence of a common mechanism makes the architecture difficult to describe and modify.
 * Lack of abstraction; all interfaces are unique to each subsystem.
@@ -57,13 +57,13 @@ System modifications become increasingly likely to introduce new serious bugs.
 * Lack of architectural vision.
 
 
-##Known Exceptions
+## Known Exceptions
 
 Research and development software production often institute the Stovepipe System AntiPattern to achieve a rapid solution.
 
 This is perfectly acceptable for prototypes and mockups; and sometimes, insufficient knowledge about a domain may require a Stovepipe System to be initially developed to gain domain information either for building a more robust system or for evolving the initial system into an improved version Or, the choice to use a vendor's product and not reinvent the wheel can lead to both the Stovepipe System AntiPattern and the Vendor Lock-In AntiPattern.
 
-##Refactored Solution
+## Refactored Solution
 
 The refactored solution to the Stovepipe System AntiPattern is a component architecture that provides for flexible substitution of software modules. Subsystems are modeled abstractly so that there are many fewer exposed interfaces than there are subsystem implementations.
 
@@ -89,7 +89,7 @@ Incorporation of metadata into the component architecture is key to service disc
 
 Interoperable naming services are extended to incorporate some trading capabilities. More extensive use of metadata is usually required for enhanced decoupling of clients from services. For example, schema metadata for database services helps clients to adapt alternative schema and schema changes
 
-##Example
+## Example
 
 figure below is a representation of a typical stovepipe system. There are three client subsystems and six service subsystems. Each subsystem has a unique software interface, and each subsystem instance is modeled as a class in the class diagram.
 
@@ -103,11 +103,11 @@ If additional devices are added to the system from these abstract subsystem cate
 
 ![Stovepipe system antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/Stovepipe System2-2-2x.png "Stovepipe system antipattern")
 
-##Related Solutions
+## Related Solutions
 
 The Stovepipe Enterprise AntiPattern describes how stovepipe practices are promulgated on an enterprise scale. Note that Stovepipe Enterprise addresses a multisystem problem, which involves a larger scale of architecture than a single system.
 
-##Applicability To Other Viewpoints And Scales
+## Applicability To Other Viewpoints And Scales
 
 The management consequences of Stovepipe Systems are: increased risk, bigger budget, and longer time to market. And because complexity increases throughout the life cycle of the system, the management problems magnify as development progresses.
 

--- a/articles/oop/anti-patterns/the-blob.md
+++ b/articles/oop/anti-patterns/the-blob.md
@@ -15,7 +15,7 @@ permalink: "/faq/object-oriented-programming/anti-patterns/blob/"
 * **Unbalanced Forces**: Management of Functionality, Performance, Complexity
 * **Anecdotal Evidence**: "This is the class that is really the heart of our architecture."
 
-##Background
+## Background
 
 Do you remember the original black-and-white movie The Blob? Perhaps you saw only the recent remake. In either case, the story line was almost the same: A drip-sized, jellylike alien life form from outer space somehow makes it to Earth.
 
@@ -25,7 +25,7 @@ The movie is a good analogy for the Blob AntiPattern, which has been known to co
 
 ![Blob antipattern](https://raw.githubusercontent.com/wwphp-fb/php-resources/master/images/anti-patterns/blob-2x.png "Blob antipattern")
 
-##General Form
+## General Form
 
 The Blob is found in designs where one class monopolizes the processing, and other classes primarily encapsulate data. This AntiPattern is characterized by a class diagram composed of a single complex controller class surrounded by simple data classes. The key problem here is that the majority of the responsibilities are allocated to a single class.
 
@@ -41,7 +41,7 @@ The Blob is also frequently a result of iterative development where proof-of-con
 
 The allocation of responsibilities is not repartitioned during system evolution, so that one module becomes predominant. The Blob is often accompanied by unnecessary code, making it hard to differentiate between the useful functionality of the Blob Class and no-longer-used code (see the Lava Flow AntiPattern).
 
-##Symptoms And Consequences
+## Symptoms And Consequences
 
 * Single class with a large number of attributes, operations, or both. A class with 60 or more attributes and operations usually indicates the presence of the Blob
 * A disparate collection of unrelated attributes and operations encapsulated in a single class. An overall lack of cohesiveness of the attributes and operations is typical of the Blob.
@@ -52,7 +52,7 @@ The allocation of responsibilities is not repartitioned during system evolution,
 * The Blob Class is typically too complex for reuse and testing. It may be inefficient, or introduce excessive complexity to reuse the Blob for subsets of its functionality.
 * The Blob Class may be expensive to load into memory, using excessive resources, even for simple operations.
 
-##Typical Causes
+## Typical Causes
 
 * Lack of an object-oriented architecture. The designers may not have an adequate understanding of object-oriented principles. Alternatively, the team may lack appropriate abstraction skills.
 * Lack of (any) architecture. The absence of definition of the system components, their interactions, and the specific use of the selected programming languages. This allows programs to evolve in an ad hoc fashion because the programming languages are used for other than their intended purposes.
@@ -60,11 +60,11 @@ The allocation of responsibilities is not repartitioned during system evolution,
 * Too limited intervention. In iterative projects, developers tend to add little pieces of functionality to existing working classes, rather than add new classes, or revise the class hierarchy for more effective allocation of responsibilities.
 * Specified disaster. Sometimes the Blob results from the way requirements are specified. If the requirements dictate a procedural solution, then architectural commitments may be made during requirements analysis that are difficult to change. Defining system architecture as part of requirements analysis is usually inappropriate, and often leads to the Blob AntiPattern, or worse.
 
-##Known Exceptions
+## Known Exceptions
 
 The Blob AntiPattern is acceptable when wrapping legacy systems. There is no software partitioning required, just a final layer of code to make the legacy system more accessible.
 
-##Refactored Solution
+## Refactored Solution
 
 As with most of the AntiPatterns in this section, the solution involves a form of refactoring. The key is to move behavior away from the Blob. It may be appropriate to reallocate behavior to some of the encapsulated data objects in a way that makes these objects more capable and the Blob less complex. The method for refactoring responsibilities is described as follows:
 
@@ -94,7 +94,7 @@ Fig 4
 5. Finally, we remove all transient associations, replacing them as appropriate with type specifiers to attributes and operations arguments.
 In our example, a Check_Out_Item or a Search_For_Item would be a transient process, and could be moved into a separate transient class with local attributes that establish the specific location or search criteria for a specific instance of a check-out or search.
 
-##Variations
+## Variations
 
 Sometimes, with a system composed of the Blob class and its supporting data objects, too much work has been invested to enable a refactoring of the class architecture. An alternative approach may be available that provides an "80%" solution.
 
@@ -106,7 +106,7 @@ Riel identifies two major forms of the Blob AntiPattern. He calls these two form
 
 The Behavioral Form is an object that contains a centralized process that interacts with most other parts of the system. The Data Form is an object that contains shared data used by most other objects in the system. Riel introduces a number of object-oriented heuristics for detect ing and refactoring God Class designs.
 
-##Applicability To Other Viewpoints And Scales
+## Applicability To Other Viewpoints And Scales
 
 Both architectural and managerial viewpoints play key roles in the initial prevention of the Blob AntiPattern. Avoidance of the Blob may require ongoing policing of the architecture to assure adequate distribution of responsibilities.
 
@@ -116,7 +116,7 @@ The most important factor is that, in most cases, it's much less expensive to cr
 
 Ask any insurance salesperson, and he or she may tell you that most insurance is purchased after it was needed by people who are poorer but wiser.
 
-##Example
+## Example
 
 A GUI module that is intended to interface to a processing module gradually takes on the processing functionality of background-processing modules. An example of this is a PowerBuilder screen for customer data entry/retrieval. The screen can:
 

--- a/articles/oop/anti-patterns/vendor-lock-in.md
+++ b/articles/oop/anti-patterns/vendor-lock-in.md
@@ -15,7 +15,7 @@ permalink: "/faq/object-oriented-programming/anti-patterns/vendor-lock-in/"
 * **Unbalanced Forces**: Management of Technology Transfer, Management of Change
 * **Anecdotal Evidence**: We have often encountered software projects that claim their architecture is based upon a particular vendor or product line. Other anecdotal evidence occurs around the time of product upgrades and new application installations: "When I try to read the new data files into the old version of the application, it crashes my system." "Once you read data into the new application, you can never get it out again." "The old software acts like it has a virus, but it's probably just the new application data." "Our architecture is.. What's the name of our database again?"
 
-##Background
+## Background
 A worst-case scenario of this AntiPattern would occur if your data and software licenses were completely allocated to online services, and one day, a modal dialog box popped up.
 
 Interactive word processing became more popular than formatting language technologies (like SGML) because it allows the user to see the final format on the computer screen and print an exact copy of the on-screen appearance. This capability is called "What you see is what you get" (WYSIWIG).
@@ -24,26 +24,32 @@ A pervasive variation of Vendor Lock-In is the phenomenon called "What you see i
 
 Documents from different versions of the same Microsoft product can cause support problems on corporate networks and system crashes. Many companies discourage or outlaw co-mingling of product versions. It is difficult to avoid this form of vendor lock-in and its product misfeatures because of organizational dependence on Microsoft's products for document interchange.
 
-##General Form
+## General Form
 A software project adopts a product technology and becomes completely dependent upon the vendor's implementation. When upgrades are done, software changes and interoperability problems occur, and continuous maintenance is required to keep the system running.
 
 In addition, expected new product features are often delayed, causing schedule slips and an inability to complete desired application software features.
 
-##Symptoms And Consequences
+## Symptoms And Consequences
+
 * Commercial product upgrades drive the application software maintenance cycle.
 * Promised product features are delayed or never delivered, subsequently, causing failure to deliver application updates.
 * The product varies significantly from the advertised open systems standard.
 * If a product upgrade is missed entirely, a product repurchase and reintegration is often necessary.
-##Typical Causes
+
+## Typical Causes
+
 * The product varies from published open system standards because there is no effective conformance process for the standard.
 * The product is selected based entirely upon marketing and sales information, and not upon more detailed technical inspection.
 * There is no technical approach for isolating application software from direct dependency upon the product.
 * Application programming requires in-depth product knowledge.
 * The complexity and generality of the product technology greatly exceeds that of the application needs; direct dependence upon the product results in failure to manage the complexity of the application system architecture.
-##Known Exceptions
+
+## Known Exceptions
+
 The Vendor Lock-In AntiPattern is acceptable when a single vendor's code makes up the majority of code needed in an application.
 
-##Refactored Solution
+## Refactored Solution
+
 The refactioned solution to the Vendor Lock-In AntiPattern is called isolation layer. An isolation layer separates software packages and technology. It can be used to provide software portability from underlying middleware and platform-specific interfaces. This solution is applicable when one or more of the following conditions apply:
 
 * Isolation of application software from lower-level infrastructure. This infrastructure may include middleware, operating systems, security mechanisms, or other low-level mechanisms.
@@ -62,7 +68,7 @@ This isolation layer is used across multiple system development projects to assu
 
 It is also necessary to install gateways between multiple infrastructures that must be supported concurrently, and to install forward and reverse gateways during infrastructure migration
 
-The benefits of this solution are:
+### The benefits of this solution are:
 
 * Mitigation of the risks and costs of infrastructure migration.
 * Precluding obsolescence caused by to infrastructure changes.
@@ -76,7 +82,9 @@ Other consequences of this solution are that:
 * The isolation layer must be migrated and maintained, potentially on multiple platforms and infrastructures.
 * The developers who define the initial isolation layer interfaces must be coordinated.
 * Changes made to the application interfaces must be coordinated.
-##Variations
+
+## Variations
+
 This solution is often used at the global level in commercial products and technologies. Typically, the isolation layer enables the vendor to provide a convenient language-specific interface to a lower-level technology. Some of this convenience comes in the form of default handling of lower-level interfaces that are more flexible than necessary for most applications.
 
 For example, the HP Object-Oriented Distributed Computing Environment (OO DCE) product comprises an isolation layer, and presents a C ++ interface to application developers. Underlying this interface is an isolation layer of software that is built upon the C language DCE environment.
@@ -85,18 +93,22 @@ Calls to the C ++ APIs can invoke several underlying DCE procedure calls; in par
 
 The isolation layer solution is most applicable at the enterprise level. However, individual systems have applied this solution to provide middleware isolation; for example, the Paragon Electronic Light Table (ELT) product uses an isolation layer above the Common Desktop Environment (CDE) middleware infrastructure, called ToolTalk. By isolating ToolTalk, Paragon can easily migrate its product to a CORBA infrastructure and support both CORBA and ToolTalk infrastructures.
 
-##Example
+## Example
+
 The following examples are three known uses of the isolation layer solution:
 
 1. The ORBlite framework, based on HP ORB plus, isolates application software from multiple language mappings and network protocols Thus, it was able to support multiple language mappings for C ++ , given the evolution of the OMG mappings during the adoption and revision process
 2. Even though OpenDoc is no longer in the product strategy of its creator, some interesting technical approaches were used, including the isolation layer solution. The OpenDoc Parts Framework (OPF) institutes a higher-level C ++ programming interface to the OpenDoc compound document interface, defined in ISO IDL. OPF includes interfaces to operating system functions (including display graphics), as well as OpenDoc functions. In doing so, OPF enables source code portability interfaces for middleware, windowing, and operating systems. Compound document parts written using OPF can be ported via recompilation and linking to OS/2, MacOS, and Windows95. A testing capability called LiveObjects, from the Component Integration Labs, the consortium responsible for OpenDoc, assures component portability and interoperability.
 3. EOSDIS (Earth Observing System Data and Information System) is a large-scale information retrieval project funded by NASA. The EOSDIS middleware abstraction layer was used to isolate application software and evolving middleware. Initial prototypes used a beta-test CORBA product. These prototyping efforts proved unsuccessful, largely due to difficulties in using the beta-test product. Although program management acknowledged the need for future CORBA support, a proprietary object-oriented DCE extension was chosen for short-term implementations. Management also did not want to rely entirely on proprietary interfaces. The situation was resolved through the addition of a middleware abstraction layer that masked the choice of middleware from EOSDIS application software; it hid differences in object creation, object activation, and object invocation.
-##Related Solutions
+
+## Related Solutions
+
 This pattern is related to the Object Wrapper pattern , which provides isolation to and from a single application to a single object infrastructure. The isolation layer pattern provides insulation of multiple applications from multiple infrastructures. This pattern is also related to the Profile pattern , where an isolation layer can be viewed as a particular enterprise profile for the use of middleware.
 
 The isolation layer can be thought of as one the levels in a layered architecture In contrast to most layers, this is a very thin layer that does not contain application objects. Typically, an isolation layer serves only as a proxy for integrating clients and services with one or more infrastructures. The Proxy pattern is described in Buschmann (1996).
 
-##Applicability To Other Viewpoints And Scales
+## Applicability To Other Viewpoints And Scales
+
 The impact of Vendor Lock-In on management is a loss of control of the technology, IT functionality, and O&M budgets to the dictates of vendor product releases. Vendor Lock-In also impacts risk management. The AntiPattern is often accepted with the understanding that future features will be implemented. Unfortunately, these feature often deliver later than expected or needed, if ever.
 
 Vendor Lock-In affects developers by requiring they have in-depth product knowledge. But this knowledge is transient; it will be made obsolete by the next product release. Thus, developers are expected to be on a continuous learning-curve treadmill about product features, product bugs, and product futures.

--- a/articles/oop/anti-patterns/walking-through-minefield.md
+++ b/articles/oop/anti-patterns/walking-through-minefield.md
@@ -18,7 +18,7 @@ The purpose of commercial software testing is to limit risk, in particular, supp
 
 With simpler systems of the past, we were lucky. When a software bug occurred, the likely outcome was that nothing happened. With today's systems, including computer-controlled passenger trains and spacecraft control systems, the outcome of a bug can be catastrophic. Already, there have been half a dozen major software failures where financial losses exceeded $100 million.
 
-##Refactored Solution
+## Refactored Solution
 
 Proper investment in software testing is required to make systems relatively bug-free. In some progressive companies, the size of testing staff exceeds programming staff The most important change to make to testing procedures is configuration control of test cases.
 
@@ -30,7 +30,7 @@ Other effective approaches for testing include automation of test execution and 
 
 In contrast, automatic test execution enables running tests in concert with the build cycle. Regression tests can be executed without manual intervention, ensuring that software modifications do not cause defects in previously tested behaviors. Test design automation supports the generation of rigorous test suites, and dozens of good tools are available to support test design automation.
 
-##Variations
+## Variations
 
 Formal verification is used in a number of applications to ensure an error-free design Formal verification involves prov-ing (in a mathematical sense) the satisfaction of requirements. Unfortunately, computer scientists trained to perform this form of analysis are relatively rare. In addition, the results of formal analysis are expensive to generate and may be subjective. Consequently, in general, we do not recommend this approach as feasible for most organizations.
 
@@ -40,7 +40,7 @@ It involves careful review of software documentation in search of defects; for e
 
 The document editor can remove defects for subsequent review by the inspection team. Quality criteria are established for initial acceptance of the document by the inspection team and completion of the inspection process. Software inspection is a particularly useful process because it can be applied at any phase of development, from the writing of initial requirements documents through coding.
 
-##Background
+## Background
 
 "Do you believe in magic?" is a question sometimes posed by savvy computer professionals. If you believe that today's software systems are robust, you certainly do believe in magic.
 

--- a/articles/oop/anti-patterns/warm-bodies.md
+++ b/articles/oop/anti-patterns/warm-bodies.md
@@ -5,26 +5,30 @@ updated: "april 25, 2015"
 group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/warm-bodies/"
 ---
-#Warm Bodies
+# Warm Bodies
+
 * **Also Known As**: Deadwood, Body Shop, Seat Warmers, Mythical Man-Month
 * **Anecdotal Evidence**: "One out of 20 programmers... produces 20 times the software compared to an average programmer."
 Ex:-There are approximately two million working software managers and developers in America. Currently, there are 200,000 additional job openings. These figures indicate a negative 10 percent unemployment rate.
 
-##Problem
+## Problem
+
 Skilled programmers are essential to the success of a software project. So-called heroic programmers are exceptionally productive, but as few as 1 in 20 have this talent. They produce an order of magnitude of more working software than an average programmer.
 
 Large-scale software projects are prevalent in many industries. These projects employ hundreds of programmers to build an enterprise system; a staff of 100 to 400 on a single project is not atypical.
 
 These large projects often involve outsourced development and contractual payments based upon labor-hours worked. Since profits are a percentage of the staff salaries, the more hours worked, the higher the profits. System requirements always change and increase during development; so there is little risk involved if the project is underbid initially; the contractor can grow the staff to meet inevitable problems and new requirements. The fallacy of adding more staff to an ongoing software project was described by Frederick Brooks in the Mythical Man-Month (1979).
 
-##Solution
+## Solution
+
 The ideal project size is four programmers; the ideal project duration is four months Software projects are subject to the same group dynamics as committee meetings (see the Design by Committee AntiPattern).
 
 Project teams that grow beyond five people generally experience escalating difficulties with group coordination. The members have trouble making efficient decisions and maintaining a common vision. Working toward a near-term deadline is essential to encourage the team to focus and begin producing a solution.
 
 We submit that extremely large projects are futile efforts. Small project teams with individual accountability are much more likely to produce successful software.
 
-##Variations
+## Variations
+
 Finding talented programmers is an important challenge for software-intensive companies. Some firms have resorted to incorporating testing as part of their hiring processes. These examinations resemble IQ tests. If the subject fails the test, he or she will probably end up on a large-scale project with hundreds of other programmers.
 
 Working with independent contractors and consultants is an effective way to acquire programming talent quickly. In some areas of the United States, hundreds of contract programmers work out of their homes, and they can be engaged via a phone call or e-mail. These contract programmers can produce significant software products for reasonable rates, compared to the project failures and overruns that result from the Warm Bodies mini-AntiPattern.

--- a/articles/oop/anti-patterns/wolf-ticket.md
+++ b/articles/oop/anti-patterns/wolf-ticket.md
@@ -6,8 +6,10 @@ group: "articles"
 permalink: "/faq/object-oriented-programming/anti-patterns/wolf-ticket/"
 ---
 
-#Wolf Ticket
-##AntiPattern Problem
+# Wolf Ticket
+
+## AntiPattern Problem
+
 There are many more information systems standards than there are mechanisms to assure conformance. Only 6 percent of information systems standards have test suites. Most of the testable standards are for programming language compilers — FORTRAN, COBOL, Ada, and so forth.
 
 A Wolf Ticket is a product that claims openness and conformance to standards that have no enforceable meaning. The products are delivered with proprietary interfaces that may vary significantly from the published standard.
@@ -20,7 +22,8 @@ Furthermore, many standards specifications are too flexible to assure interopera
 
 Wolf Tickets are a significant problem for de facto standards (an informal standard established through popular usage or market exposure). Unfortunately, some de facto standards have no effective specification; for example, a nascent database technology that is commercially available with multiple proprietary interfaces, unique to each vendor, has become a de facto standard.
 
-##Refactored Solution
+## Refactored Solution
+
 Technology gaps cause deficiencies in specifications, product availability, conformance, interoperability, robustness, and functionality. The closing of these gaps is necessary to enable the delivery of whole products, those comprising the infrastructure and services necessary for the realization of useful systems.
 
 In the 1960s, a sophisticated user group called SHAPE advised the industry to stabilize technology and create whole products for the computer mainframe market, required for the realization of successful nonstovepipe systems. As a result, the mainframe workset remains the only whole-product information technology market.
@@ -39,10 +42,12 @@ These services apply to mission-critical systems in any domain. Naming is a whit
 
 Transactions assure robust access to state information and orderly cleanup in case of failures. System management is required for maintaining heterogeneous hardware and software environments. Because today, developers cannot buy these whole products in a robust, interworking form, developers are forced to re-create these services or build stovepipe systems.
 
-##Variation
+## Variation
+
 All computer technology consumers can participate in improving the technologies that they are currently using. To do so, simply call the vendor with your questions, complaints, and support problems.
 
 Keep in mind, for shrink-wrap products, the profit margin is less than the resources required to answer a phone call and address your questions. Most vendors track the support issues and incorporate relevant changes into their products in future releases. The priority for changes is usually based upon the frequency and urgency of the reported problems.
 
-##Background
+## Background
+
 The term Wolf Ticket originates from its slang use, where it is an unofficial pass sold to an event, such as a rock concert, by scalpers.


### PR DESCRIPTION
Most of the articles pages had broken markdown. That displayed markdown syntax when viewed.

Added an extra space so parser can show them correctly.