### PR TITLE
[SSL FAQ] Cloudflare is bad for SSL

### DIFF
--- a/faq/security/07-ssl.md
+++ b/faq/security/07-ssl.md
@@ -20,7 +20,6 @@ Some recommended resources to check:
 * [Let's Encrypt](https://letsencrypt.org/) - Free SSL/TLS certificates (US based Certification Authority).
 * [Certbot](https://certbot.eff.org/) - Automatically enable HTTPS on hosts with console access to your website
   with EFF's Certbot, deploying Let's Encrypt certificates.
-* [Cloudfare](https://www.cloudflare.com/) - Provider with multiple supercharging
   packages for websites including free HTTPS.
 * [SSL Server Test](https://www.ssllabs.com/ssltest/) - Online tool to test SSL
   on a webserver.


### PR DESCRIPTION
They actually use one certificate for multiple sites(like you could be sharing a certificate with some unsavory sites...which is bad). Let's not mention it. 